### PR TITLE
Finally fix timestamping on messages to not fail units

### DIFF
--- a/sense-go/messaging/message.go
+++ b/sense-go/messaging/message.go
@@ -226,7 +226,7 @@ type PictureTakenMessage struct {
 	MessageType           string `json:"message_type"`
 }
 
-func NewSwitchStatusChangeMessage(switch_name string, on bool) (pmsg *SwitchStatusChangeMessage) {
+func NewSwitchStatusChangeMessage(switch_name string, on bool, sampleTimeStamp int64) (pmsg *SwitchStatusChangeMessage) {
 	msg := SwitchStatusChangeMessage{
 		DeviceId:      globals.MyDevice.DeviceID,
 		StationId:     globals.MyStation.StationID,
@@ -235,7 +235,7 @@ func NewSwitchStatusChangeMessage(switch_name string, on bool) (pmsg *SwitchStat
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		EventTimestamp: GetNowMillis(),
+		EventTimestamp: sampleTimeStamp,
 		MessageType:    "switch_event",
 		SwitchName:     switch_name,
 		On:             on}
@@ -243,7 +243,7 @@ func NewSwitchStatusChangeMessage(switch_name string, on bool) (pmsg *SwitchStat
 
 }
 
-func NewDispenserStatusChangeMessage(dispenser_name string, on bool) (pmsg *DispenserStatusChangeMessage) {
+func NewDispenserStatusChangeMessage(dispenser_name string, on bool, sampleTimestamp int64) (pmsg *DispenserStatusChangeMessage) {
 	msg := DispenserStatusChangeMessage{
 		DeviceId:      globals.MyDevice.DeviceID,
 		StationId:     globals.MyStation.StationID,
@@ -252,7 +252,7 @@ func NewDispenserStatusChangeMessage(dispenser_name string, on bool) (pmsg *Disp
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		EventTimestamp: GetNowMillis(),
+		EventTimestamp: sampleTimestamp,
 		MessageType:    "dispenser_event",
 		DispenserName:  dispenser_name,
 		On:             on}
@@ -260,7 +260,7 @@ func NewDispenserStatusChangeMessage(dispenser_name string, on bool) (pmsg *Disp
 
 }
 
-func NewPictureTakenMessage(PictureFilename string, PictureDatetimeMillis int64) (pmsg *PictureTakenMessage) {
+func NewPictureTakenMessage(PictureFilename string, PictureDatetimeMillis int64, sampleTimestamp int64) (pmsg *PictureTakenMessage) {
 	msg := PictureTakenMessage{
 		DeviceId:      globals.MyDevice.DeviceID,
 		StationId:     globals.MyStation.StationID,
@@ -269,7 +269,7 @@ func NewPictureTakenMessage(PictureFilename string, PictureDatetimeMillis int64)
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		EventTimestamp:        GetNowMillis(),
+		EventTimestamp:        sampleTimestamp,
 		MessageType:           "picture_event",
 		PictureFilename:       PictureFilename,
 		PictureDateTimeMillis: PictureDatetimeMillis,
@@ -278,7 +278,7 @@ func NewPictureTakenMessage(PictureFilename string, PictureDatetimeMillis int64)
 
 }
 
-func NewVOCSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string) (pmsg *VOCSensorMessage) {
+func NewVOCSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, sampleTimestamp int64) (pmsg *VOCSensorMessage) {
 	msg := VOCSensorMessage{
 		DeviceId:        globals.MyDevice.DeviceID,
 		StationId:       globals.MyStation.StationID,
@@ -289,7 +289,7 @@ func NewVOCSensorMessage(sensor_name string, measurement_name string, value floa
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimestamp,
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -300,7 +300,7 @@ func NewVOCSensorMessage(sensor_name string, measurement_name string, value floa
 	return &msg
 }
 
-func NewCO2SensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string) (pmsg *CO2SensorMessage) {
+func NewCO2SensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, sampleTimestamp int64) (pmsg *CO2SensorMessage) {
 	msg := CO2SensorMessage{
 		DeviceId:        globals.MyDevice.DeviceID,
 		StationId:       globals.MyStation.StationID,
@@ -311,7 +311,7 @@ func NewCO2SensorMessage(sensor_name string, measurement_name string, value floa
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimestamp,
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -332,8 +332,7 @@ func NewCCS811CurrentMessage(sensor_name string, measurement_name string, value 
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SensorName: sensor_name,
-		//		SampleTimestamp: GetNowMillis(),
+		SensorName:      sensor_name,
 		SampleTimestamp: sampleTimeStamp,
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
@@ -344,7 +343,7 @@ func NewCCS811CurrentMessage(sensor_name string, measurement_name string, value 
 	return &msg
 }
 
-func NewCCS811VoltageMessage(sensor_name string, measurement_name string, value float64, units string, direction string) (pmsg *CCS811VoltageMessage) {
+func NewCCS811VoltageMessage(sensor_name string, measurement_name string, value float64, units string, direction string, sampleTimeStamp int64) (pmsg *CCS811VoltageMessage) {
 	msg := CCS811VoltageMessage{
 		DeviceId:        globals.MyDevice.DeviceID,
 		StationId:       globals.MyStation.StationID,
@@ -355,7 +354,7 @@ func NewCCS811VoltageMessage(sensor_name string, measurement_name string, value 
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimeStamp,
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -365,7 +364,7 @@ func NewCCS811VoltageMessage(sensor_name string, measurement_name string, value 
 	return &msg
 }
 
-func NewGenericSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string) (pmsg *GenericSensorMessage) {
+func NewGenericSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, sampleTimestamp int64) (pmsg *GenericSensorMessage) {
 	msg := GenericSensorMessage{
 		DeviceId:        globals.MyDevice.DeviceID,
 		StationId:       globals.MyStation.StationID,
@@ -376,7 +375,7 @@ func NewGenericSensorMessage(sensor_name string, measurement_name string, value 
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimestamp,
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -387,7 +386,7 @@ func NewGenericSensorMessage(sensor_name string, measurement_name string, value 
 	return &msg
 }
 
-func NewADCSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, channel int, gain int, rate int) (pmsg *ADCSensorMessage) {
+func NewADCSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, channel int, gain int, rate int, sampleTimestamp int64) (pmsg *ADCSensorMessage) {
 	msg := ADCSensorMessage{
 		DeviceId:      globals.MyDevice.DeviceID,
 		StationId:     globals.MyStation.StationID,
@@ -396,7 +395,7 @@ func NewADCSensorMessage(sensor_name string, measurement_name string, value floa
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimestamp,
 		MessageType:     globals.Message_type_measurement,
 		SensorName:      sensor_name,
 		MeasurementName: measurement_name,
@@ -412,7 +411,7 @@ func NewADCSensorMessage(sensor_name string, measurement_name string, value floa
 	return &msg
 }
 
-func NewDistanceSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, distanceCm float64, distanceIn float64) (pmsg *DistanceSensorMessage) {
+func NewDistanceSensorMessage(sensor_name string, measurement_name string, value float64, units string, direction string, distanceCm float64, distanceIn float64, sampleTimestamp int64) (pmsg *DistanceSensorMessage) {
 	msg := DistanceSensorMessage{
 		DeviceId:      globals.MyDevice.DeviceID,
 		StationId:     globals.MyStation.StationID,
@@ -421,7 +420,7 @@ func NewDistanceSensorMessage(sensor_name string, measurement_name string, value
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimestamp,
 		MessageType:     globals.Message_type_measurement,
 		SensorName:      sensor_name,
 		MeasurementName: measurement_name,
@@ -436,7 +435,7 @@ func NewDistanceSensorMessage(sensor_name string, measurement_name string, value
 	return &msg
 }
 
-func NewTamperSensorMessage(sensor_name string, value float64, units string, direction string, moveX float64, moveY float64, moveZ float64) (pmsg *TamperEventMessage) {
+func NewTamperSensorMessage(sensor_name string, value float64, units string, direction string, moveX float64, moveY float64, moveZ float64, sampleTimestamp int64) (pmsg *TamperEventMessage) {
 	msg := TamperEventMessage{
 		DeviceId:      globals.MyDevice.DeviceID,
 		StationId:     globals.MyStation.StationID,
@@ -445,7 +444,7 @@ func NewTamperSensorMessage(sensor_name string, value float64, units string, dir
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimestamp,
 		MessageType:     "event",
 		SensorName:      sensor_name,
 		MeasurementName: "tamper",

--- a/sense-go/messaging/message.go
+++ b/sense-go/messaging/message.go
@@ -31,7 +31,7 @@ import (
 	"time"
 )
 
-func getNowMillis() int64 {
+func GetNowMillis() int64 {
 	now := time.Now()
 	nanos := now.UnixNano()
 	millis := nanos / 1000000
@@ -235,7 +235,7 @@ func NewSwitchStatusChangeMessage(switch_name string, on bool) (pmsg *SwitchStat
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		EventTimestamp: getNowMillis(),
+		EventTimestamp: GetNowMillis(),
 		MessageType:    "switch_event",
 		SwitchName:     switch_name,
 		On:             on}
@@ -252,7 +252,7 @@ func NewDispenserStatusChangeMessage(dispenser_name string, on bool) (pmsg *Disp
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		EventTimestamp: getNowMillis(),
+		EventTimestamp: GetNowMillis(),
 		MessageType:    "dispenser_event",
 		DispenserName:  dispenser_name,
 		On:             on}
@@ -269,7 +269,7 @@ func NewPictureTakenMessage(PictureFilename string, PictureDatetimeMillis int64)
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		EventTimestamp:        getNowMillis(),
+		EventTimestamp:        GetNowMillis(),
 		MessageType:           "picture_event",
 		PictureFilename:       PictureFilename,
 		PictureDateTimeMillis: PictureDatetimeMillis,
@@ -289,7 +289,7 @@ func NewVOCSensorMessage(sensor_name string, measurement_name string, value floa
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -311,7 +311,7 @@ func NewCO2SensorMessage(sensor_name string, measurement_name string, value floa
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -322,7 +322,7 @@ func NewCO2SensorMessage(sensor_name string, measurement_name string, value floa
 	return &msg
 }
 
-func NewCCS811CurrentMessage(sensor_name string, measurement_name string, value float64, units string, direction string) (pmsg *CCS811CurrentMessage) {
+func NewCCS811CurrentMessage(sensor_name string, measurement_name string, value float64, units string, direction string, sampleTimeStamp int64) (pmsg *CCS811CurrentMessage) {
 	msg := CCS811CurrentMessage{
 		DeviceId:        globals.MyDevice.DeviceID,
 		StationId:       globals.MyStation.StationID,
@@ -332,8 +332,9 @@ func NewCCS811CurrentMessage(sensor_name string, measurement_name string, value 
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SensorName:      sensor_name,
-		SampleTimestamp: getNowMillis(),
+		SensorName: sensor_name,
+		//		SampleTimestamp: GetNowMillis(),
+		SampleTimestamp: sampleTimeStamp,
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -354,7 +355,7 @@ func NewCCS811VoltageMessage(sensor_name string, measurement_name string, value 
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -375,7 +376,7 @@ func NewGenericSensorMessage(sensor_name string, measurement_name string, value 
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
 		SensorName:      sensor_name,
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     globals.Message_type_measurement,
 		Value:           value,
 		FloatValue:      value,
@@ -395,7 +396,7 @@ func NewADCSensorMessage(sensor_name string, measurement_name string, value floa
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     globals.Message_type_measurement,
 		SensorName:      sensor_name,
 		MeasurementName: measurement_name,
@@ -420,7 +421,7 @@ func NewDistanceSensorMessage(sensor_name string, measurement_name string, value
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     globals.Message_type_measurement,
 		SensorName:      sensor_name,
 		MeasurementName: measurement_name,
@@ -444,7 +445,7 @@ func NewTamperSensorMessage(sensor_name string, value float64, units string, dir
 		ExecutableVersion: fmt.Sprintf("%s.%s.%s %s %s",
 			globals.BubblesnetVersionMajorString, globals.BubblesnetVersionMinorString,
 			globals.BubblesnetVersionPatchString, globals.BubblesnetBuildTimestamp, globals.BubblesnetGitHash),
-		SampleTimestamp: getNowMillis(),
+		SampleTimestamp: GetNowMillis(),
 		MessageType:     "event",
 		SensorName:      sensor_name,
 		MeasurementName: "tamper",

--- a/sense-go/messaging/message_test.go
+++ b/sense-go/messaging/message_test.go
@@ -72,8 +72,7 @@ func TestNewADCSensorMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPmsg := NewADCSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.channel, tt.args.gain, tt.args.rate)
-			tt.wantPmsg.SampleTimestamp = gotPmsg.SampleTimestamp
+			gotPmsg := NewADCSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.channel, tt.args.gain, tt.args.rate, tt.wantPmsg.SampleTimestamp)
 			if !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewADCSensorMessage() got  %#v", gotPmsg)
 				t.Errorf("NewADCSensorMessage() want %#v", tt.wantPmsg)
@@ -121,8 +120,7 @@ func TestNewDistanceSensorMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPmsg := NewDistanceSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.distanceCm, tt.args.distanceIn)
-			tt.wantPmsg.SampleTimestamp = gotPmsg.SampleTimestamp
+			gotPmsg := NewDistanceSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.distanceCm, tt.args.distanceIn, tt.wantPmsg.SampleTimestamp)
 			if !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewDistanceSensorMessage() got  %#v", gotPmsg)
 				t.Errorf("NewDistanceSensorMessage() want %#v", tt.wantPmsg)
@@ -167,8 +165,7 @@ func TestNewGenericSensorMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.wantPmsg.SampleTimestamp = GetNowMillis()
-			gotPmsg := NewGenericSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction)
-			tt.wantPmsg.SampleTimestamp = gotPmsg.SampleTimestamp
+			gotPmsg := NewGenericSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction, tt.wantPmsg.SampleTimestamp)
 			if !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewGenericSensorMessage() got  %#v", gotPmsg)
 				t.Errorf("NewGenericSensorMessage() want %#v", tt.wantPmsg)
@@ -224,8 +221,7 @@ func TestNewTamperSensorMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.wantPmsg.SampleTimestamp = GetNowMillis()
-			gotPmsg := NewTamperSensorMessage(tt.args.sensor_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.moveX, tt.args.moveY, tt.args.moveZ)
-			tt.wantPmsg.SampleTimestamp = gotPmsg.SampleTimestamp
+			gotPmsg := NewTamperSensorMessage(tt.args.sensor_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.moveX, tt.args.moveY, tt.args.moveZ, tt.wantPmsg.SampleTimestamp)
 			if !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewTamperSensorMessage() = got  %#v", gotPmsg)
 				t.Errorf("NewTamperSensorMessage() = want %#v", tt.wantPmsg)
@@ -277,7 +273,7 @@ func TestNewSwitchStatusChangeMessage(t *testing.T) {
 	for _, tt := range tests {
 		testmsg.EventTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
-			if gotPmsg := NewSwitchStatusChangeMessage(tt.args.switch_name, tt.args.on); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
+			if gotPmsg := NewSwitchStatusChangeMessage(tt.args.switch_name, tt.args.on, testmsg.EventTimestamp); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				// This timestamp hack will cause false negatives if timestamp error coincides with other error
 				if gotPmsg.EventTimestamp == tt.wantPmsg.EventTimestamp {
 					t.Errorf("NewSwitchStatusChangeMessage() = got  %#v", gotPmsg)
@@ -326,7 +322,7 @@ func TestNewVOCSensorMessage(t *testing.T) {
 		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewVOCSensorMessage(tt.args.sensor_name, tt.args.measurement_name,
-				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
+				tt.args.value, tt.args.units, tt.args.direction, testmsg.SampleTimestamp); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("TestNewVOCSensorMessage() = got  %#v", gotPmsg)
 				t.Errorf("TestNewVOCSensorMessage() = want %#v", tt.wantPmsg)
 			}
@@ -372,7 +368,7 @@ func TestNewCO2SensorMessage(t *testing.T) {
 		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewCO2SensorMessage(tt.args.sensor_name, tt.args.measurement_name,
-				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
+				tt.args.value, tt.args.units, tt.args.direction, testmsg.SampleTimestamp); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("TestNewCO2SensorMessage() = got  %#v", gotPmsg)
 				t.Errorf("TestNewCO2SensorMessage() = want %#v", tt.wantPmsg)
 			}
@@ -468,7 +464,7 @@ func TestNewCCS811VoltageMessage(t *testing.T) {
 		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewCCS811VoltageMessage(tt.args.sensor_name, tt.args.measurement_name,
-				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
+				tt.args.value, tt.args.units, tt.args.direction, testmsg.SampleTimestamp); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewCCS811VoltageMessage() = got  %#v", gotPmsg)
 				t.Errorf("NewCCS811VoltageMessage() = want %#v", tt.wantPmsg)
 			}
@@ -497,7 +493,7 @@ func TestNewPictureTakenMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testmsg.EventTimestamp = GetNowMillis()
-			if gotPmsg := NewPictureTakenMessage("blah.jpg", 0); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
+			if gotPmsg := NewPictureTakenMessage("blah.jpg", 0, testmsg.EventTimestamp); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewPictureTakenMessage() got  %#v", gotPmsg)
 				t.Errorf("NewPictureTakenMessage() want %#v", tt.wantPmsg)
 			}

--- a/sense-go/messaging/message_test.go
+++ b/sense-go/messaging/message_test.go
@@ -54,7 +54,7 @@ func TestNewADCSensorMessage(t *testing.T) {
 				SiteId:    1,
 				StationId: 1,
 
-				SampleTimestamp:   getNowMillis(),
+				SampleTimestamp:   GetNowMillis(),
 				ContainerName:     globals.CONTAINER_NAME_SENSE_GO,
 				MeasurementName:   "",
 				MessageType:       globals.Message_type_measurement,
@@ -104,7 +104,7 @@ func TestNewDistanceSensorMessage(t *testing.T) {
 				SiteId:            1,
 				StationId:         1,
 				DeviceId:          globals.MyDevice.DeviceID,
-				SampleTimestamp:   getNowMillis(),
+				SampleTimestamp:   GetNowMillis(),
 				ContainerName:     globals.CONTAINER_NAME_SENSE_GO,
 				MessageType:       globals.Message_type_measurement,
 				ExecutableVersion: "..  ",
@@ -151,7 +151,7 @@ func TestNewGenericSensorMessage(t *testing.T) {
 				SiteId:            1,
 				StationId:         1,
 				DeviceId:          globals.MyDevice.DeviceID,
-				SampleTimestamp:   getNowMillis(),
+				SampleTimestamp:   GetNowMillis(),
 				ContainerName:     globals.CONTAINER_NAME_SENSE_GO,
 				MessageType:       globals.Message_type_measurement,
 				ExecutableVersion: "..  ",
@@ -166,7 +166,7 @@ func TestNewGenericSensorMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.wantPmsg.SampleTimestamp = getNowMillis()
+			tt.wantPmsg.SampleTimestamp = GetNowMillis()
 			gotPmsg := NewGenericSensorMessage(tt.args.sensor_name, tt.args.measurement_name, tt.args.value, tt.args.units, tt.args.direction)
 			tt.wantPmsg.SampleTimestamp = gotPmsg.SampleTimestamp
 			if !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
@@ -205,7 +205,7 @@ func TestNewTamperSensorMessage(t *testing.T) {
 				SiteId:            1,
 				StationId:         1,
 				DeviceId:          globals.MyDevice.DeviceID,
-				SampleTimestamp:   getNowMillis(),
+				SampleTimestamp:   GetNowMillis(),
 				ContainerName:     globals.CONTAINER_NAME_SENSE_GO,
 				MessageType:       "event",
 				ExecutableVersion: "..  ",
@@ -223,7 +223,7 @@ func TestNewTamperSensorMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.wantPmsg.SampleTimestamp = getNowMillis()
+			tt.wantPmsg.SampleTimestamp = GetNowMillis()
 			gotPmsg := NewTamperSensorMessage(tt.args.sensor_name, tt.args.value, tt.args.units, tt.args.direction, tt.args.moveX, tt.args.moveY, tt.args.moveZ)
 			tt.wantPmsg.SampleTimestamp = gotPmsg.SampleTimestamp
 			if !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
@@ -243,8 +243,8 @@ func Test_getNowMillis(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getNowMillis(); got != tt.want {
-				t.Errorf("getNowMillis() = %#v, want %#v", got, tt.want)
+			if got := GetNowMillis(); got != tt.want {
+				t.Errorf("GetNowMillis() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}
@@ -258,7 +258,7 @@ func TestNewSwitchStatusChangeMessage(t *testing.T) {
 		StationId:         1,
 		ContainerName:     globals.CONTAINER_NAME_SENSE_GO,
 		ExecutableVersion: "..  ",
-		EventTimestamp:    getNowMillis(),
+		EventTimestamp:    GetNowMillis(),
 		MessageType:       "switch_event",
 		SwitchName:        "testswitch",
 		On:                true,
@@ -275,7 +275,7 @@ func TestNewSwitchStatusChangeMessage(t *testing.T) {
 		{name: "happy", args: args{switch_name: "testswitch", on: true}, wantPmsg: &testmsg},
 	}
 	for _, tt := range tests {
-		testmsg.EventTimestamp = getNowMillis()
+		testmsg.EventTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewSwitchStatusChangeMessage(tt.args.switch_name, tt.args.on); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				// This timestamp hack will cause false negatives if timestamp error coincides with other error
@@ -323,7 +323,7 @@ func TestNewVOCSensorMessage(t *testing.T) {
 			direction: globals.Directions_none}, wantPmsg: &testmsg},
 	}
 	for _, tt := range tests {
-		testmsg.SampleTimestamp = getNowMillis()
+		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewVOCSensorMessage(tt.args.sensor_name, tt.args.measurement_name,
 				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
@@ -369,7 +369,7 @@ func TestNewCO2SensorMessage(t *testing.T) {
 			direction: globals.Directions_none}, wantPmsg: &testmsg},
 	}
 	for _, tt := range tests {
-		testmsg.SampleTimestamp = getNowMillis()
+		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewCO2SensorMessage(tt.args.sensor_name, tt.args.measurement_name,
 				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
@@ -405,6 +405,8 @@ func TestNewCCS811CurrentMessage(t *testing.T) {
 		direction        string
 	}
 
+	sampleTimestamp := GetNowMillis()
+
 	tests := []struct {
 		name     string
 		args     args
@@ -416,10 +418,10 @@ func TestNewCCS811CurrentMessage(t *testing.T) {
 			direction: globals.Directions_none}, wantPmsg: &testmsg},
 	}
 	for _, tt := range tests {
-		testmsg.SampleTimestamp = getNowMillis()
+		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewCCS811CurrentMessage(tt.args.sensor_name, tt.args.measurement_name,
-				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
+				tt.args.value, tt.args.units, tt.args.direction, sampleTimestamp); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewCCS811CurrentMessage() = got  %#v", gotPmsg)
 				t.Errorf("NewCCS811CurrentMessage() = want %#v", tt.wantPmsg)
 			}
@@ -463,7 +465,7 @@ func TestNewCCS811VoltageMessage(t *testing.T) {
 			direction: globals.Directions_none}, wantPmsg: &testmsg},
 	}
 	for _, tt := range tests {
-		testmsg.SampleTimestamp = getNowMillis()
+		testmsg.SampleTimestamp = GetNowMillis()
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPmsg := NewCCS811VoltageMessage(tt.args.sensor_name, tt.args.measurement_name,
 				tt.args.value, tt.args.units, tt.args.direction); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
@@ -482,7 +484,7 @@ func TestNewPictureTakenMessage(t *testing.T) {
 		DeviceId:          70000008,
 		ContainerName:     globals.CONTAINER_NAME_SENSE_GO,
 		ExecutableVersion: "..  ",
-		EventTimestamp:    getNowMillis(),
+		EventTimestamp:    GetNowMillis(),
 		MessageType:       "picture_event",
 		PictureFilename:   "blah.jpg",
 	}
@@ -494,7 +496,7 @@ func TestNewPictureTakenMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testmsg.EventTimestamp = getNowMillis()
+			testmsg.EventTimestamp = GetNowMillis()
 			if gotPmsg := NewPictureTakenMessage("blah.jpg", 0); !reflect.DeepEqual(gotPmsg, tt.wantPmsg) {
 				t.Errorf("NewPictureTakenMessage() got  %#v", gotPmsg)
 				t.Errorf("NewPictureTakenMessage() want %#v", tt.wantPmsg)

--- a/sense-go/modules/a2dconverter/adc.go
+++ b/sense-go/modules/a2dconverter/adc.go
@@ -179,7 +179,7 @@ func getADCSensorMessageForChannel(adcMessage *ADCMessage, moduleIndex int, chan
 	ads := messaging.NewADCSensorMessage(sensorName, sensorName,
 		adcMessage.ChannelValues[channelIndex].Voltage, globals.UNIT_VOLTS,
 		direction,
-		adcMessage.ChannelValues[channelIndex].ChannelNumber, adcMessage.ChannelValues[channelIndex].Gain, adcMessage.ChannelValues[channelIndex].Rate)
+		adcMessage.ChannelValues[channelIndex].ChannelNumber, adcMessage.ChannelValues[channelIndex].Gain, adcMessage.ChannelValues[channelIndex].Rate, messaging.GetNowMillis())
 	bytearray, err := json.Marshal(ads)
 	if err != nil {
 		log.Errorf("ads1115: loopforever error %#v", err)
@@ -215,7 +215,7 @@ func getTranslatedADCSensorMessageForChannel(adcMessage *ADCMessage, moduleIndex
 			globals.LastWaterLevel = float32(measurementValue)
 
 			ads := messaging.NewGenericSensorMessage(sensorName, measurementName,
-				measurementValue, measurementUnits, direction)
+				measurementValue, measurementUnits, direction, messaging.GetNowMillis())
 			bytearray, err := json.Marshal(ads)
 			if err != nil {
 				log.Errorf("ads1115: loopforever error %#v", err)

--- a/sense-go/modules/accelerometer/tamper_detector.go
+++ b/sense-go/modules/accelerometer/tamper_detector.go
@@ -80,7 +80,7 @@ func (r *RealTamperDetector) RunTamperDetector(onceOnly bool) {
 				if xmove > globals.MyStation.TamperSpec.Xmove || ymove > globals.MyStation.TamperSpec.Ymove || zmove > globals.MyStation.TamperSpec.Zmove {
 					log.Infof("adxl345: new tamper message !! x: %.3f | y: %.3f | z: %.3f ", xmove, ymove, zmove)
 					var tamperMessage = messaging.NewTamperSensorMessage(globals.Sensor_name_tamper_sensor,
-						0.0, "", "", xmove, ymove, zmove)
+						0.0, "", "", xmove, ymove, zmove, messaging.GetNowMillis())
 					bytearray, err := json.Marshal(tamperMessage)
 					if err != nil {
 						fmt.Println(err)

--- a/sense-go/modules/camera/uploader.go
+++ b/sense-go/modules/camera/uploader.go
@@ -45,7 +45,7 @@ import (
 )
 
 func SendPictureTakenEvent(PictureFilename string, PictureDatetimeMillis int64) {
-	dm := messaging.NewPictureTakenMessage(PictureFilename, PictureDatetimeMillis)
+	dm := messaging.NewPictureTakenMessage(PictureFilename, PictureDatetimeMillis, messaging.GetNowMillis())
 	bytearray, err := json.Marshal(dm)
 	message := pb.SensorRequest{Sequence: globals.GetSequence(), TypeId: globals.Grpc_message_typeid_picture, Data: string(bytearray)}
 	_, err = globals.Client.StoreAndForward(context.Background(), &message)

--- a/sense-go/modules/co2vocmeter/co2voc.go
+++ b/sense-go/modules/co2vocmeter/co2voc.go
@@ -278,7 +278,7 @@ func ReadCO2VOC(ptemp *float32, phumidity *float32) {
 
 				typeId := globals.Grpc_message_typeid_sensor
 
-				co2m, vocm, curm, voltm := getCCCS811SensorMessages(sensorValues)
+				co2m, vocm, curm, voltm := getCCS811SensorMessages(sensorValues)
 				log.Infof("ccs811: co2m = %#v", co2m)
 				bytearray, err := json.Marshal(co2m)
 				if err != nil {
@@ -442,13 +442,13 @@ func reportStatus(status byte) (statstring string) {
 	return statstring
 }
 
-func getCCCS811SensorMessages(sensorValues ccs811.SensorValues) (co2msg *messaging.CO2SensorMessage, vocmsg *messaging.VOCSensorMessage,
+func getCCS811SensorMessages(sensorValues ccs811.SensorValues) (co2msg *messaging.CO2SensorMessage, vocmsg *messaging.VOCSensorMessage,
 	rawcurrentmsg *messaging.CCS811CurrentMessage, rawvoltagemsg *messaging.CCS811VoltageMessage) {
 
 	co2msg = messaging.NewCO2SensorMessage("co2_sensor", "co2", float64(sensorValues.ECO2), "ppm", "")
 	vocmsg = messaging.NewVOCSensorMessage("voc_sensor", "voc", float64(sensorValues.VOC), "ppb", "")
 	rawcurrentmsg = messaging.NewCCS811CurrentMessage("ccs811_current_sensor", "ccs811_rawcurrent",
-		float64(sensorValues.RawDataCurrent), "ua", "")
+		float64(sensorValues.RawDataCurrent), "ua", "", messaging.GetNowMillis())
 	rawvoltagemsg = messaging.NewCCS811VoltageMessage("ccs811_voltage_sensor", "ccs811_rawvoltage",
 		float64(sensorValues.RawDataVoltage), "uv", "")
 

--- a/sense-go/modules/co2vocmeter/co2voc.go
+++ b/sense-go/modules/co2vocmeter/co2voc.go
@@ -445,12 +445,12 @@ func reportStatus(status byte) (statstring string) {
 func getCCS811SensorMessages(sensorValues ccs811.SensorValues) (co2msg *messaging.CO2SensorMessage, vocmsg *messaging.VOCSensorMessage,
 	rawcurrentmsg *messaging.CCS811CurrentMessage, rawvoltagemsg *messaging.CCS811VoltageMessage) {
 
-	co2msg = messaging.NewCO2SensorMessage("co2_sensor", "co2", float64(sensorValues.ECO2), "ppm", "")
-	vocmsg = messaging.NewVOCSensorMessage("voc_sensor", "voc", float64(sensorValues.VOC), "ppb", "")
+	co2msg = messaging.NewCO2SensorMessage("co2_sensor", "co2", float64(sensorValues.ECO2), "ppm", "", messaging.GetNowMillis())
+	vocmsg = messaging.NewVOCSensorMessage("voc_sensor", "voc", float64(sensorValues.VOC), "ppb", "", messaging.GetNowMillis())
 	rawcurrentmsg = messaging.NewCCS811CurrentMessage("ccs811_current_sensor", "ccs811_rawcurrent",
 		float64(sensorValues.RawDataCurrent), "ua", "", messaging.GetNowMillis())
 	rawvoltagemsg = messaging.NewCCS811VoltageMessage("ccs811_voltage_sensor", "ccs811_rawvoltage",
-		float64(sensorValues.RawDataVoltage), "uv", "")
+		float64(sensorValues.RawDataVoltage), "uv", "", messaging.GetNowMillis())
 
 	return co2msg, vocmsg, rawcurrentmsg, rawvoltagemsg
 }

--- a/sense-go/modules/co2vocmeter/co2voc_test.go
+++ b/sense-go/modules/co2vocmeter/co2voc_test.go
@@ -81,18 +81,18 @@ func Test_getCCCS811SensorMessages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCo2msg, gotVocmsg, gotRawcurrentmsg, gotRawvoltagemsg := getCCCS811SensorMessages(tt.args.sensorValues)
+			gotCo2msg, gotVocmsg, gotRawcurrentmsg, gotRawvoltagemsg := getCCS811SensorMessages(tt.args.sensorValues)
 			if !reflect.DeepEqual(gotCo2msg, tt.wantCo2msg) {
-				t.Errorf("getCCCS811SensorMessages() gotCo2msg = %v, want %v", gotCo2msg, tt.wantCo2msg)
+				t.Errorf("getCCS811SensorMessages() gotCo2msg = %v, want %v", gotCo2msg, tt.wantCo2msg)
 			}
 			if !reflect.DeepEqual(gotVocmsg, tt.wantVocmsg) {
-				t.Errorf("getCCCS811SensorMessages() gotVocmsg = %v, want %v", gotVocmsg, tt.wantVocmsg)
+				t.Errorf("getCCS811SensorMessages() gotVocmsg = %v, want %v", gotVocmsg, tt.wantVocmsg)
 			}
 			if !reflect.DeepEqual(gotRawcurrentmsg, tt.wantRawcurrentmsg) {
-				t.Errorf("getCCCS811SensorMessages() gotRawcurrentmsg = %v, want %v", gotRawcurrentmsg, tt.wantRawcurrentmsg)
+				t.Errorf("getCCS811SensorMessages() gotRawcurrentmsg = %v, want %v", gotRawcurrentmsg, tt.wantRawcurrentmsg)
 			}
 			if !reflect.DeepEqual(gotRawvoltagemsg, tt.wantRawvoltagemsg) {
-				t.Errorf("getCCCS811SensorMessages() gotRawvoltagemsg = %v, want %v", gotRawvoltagemsg, tt.wantRawvoltagemsg)
+				t.Errorf("getCCS811SensorMessages() gotRawvoltagemsg = %v, want %v", gotRawvoltagemsg, tt.wantRawvoltagemsg)
 			}
 		})
 	}

--- a/sense-go/modules/distancesensor/hcsr_04.go
+++ b/sense-go/modules/distancesensor/hcsr_04.go
@@ -76,7 +76,7 @@ func RunDistanceWatcher1(once_only bool, isUnitTest bool) {
 		}
 		lastDistance = mydistance
 		//		log.Debugf("%.2f inches %.2f distance %.2f nanos %.2f cm\n", distance/2.54, distance, nanos, mydistance))
-		dm := messaging.NewDistanceSensorMessage(globals.Sensor_name_height_sensor, globals.Measurement_name_plant_height, mydistance, globals.Distance_units_centimeters, direction, mydistance, mydistance/2.54)
+		dm := messaging.NewDistanceSensorMessage(globals.Sensor_name_height_sensor, globals.Measurement_name_plant_height, mydistance, globals.Distance_units_centimeters, direction, mydistance, mydistance/2.54, messaging.GetNowMillis())
 		bytearray, err := json.Marshal(dm)
 		if err == nil {
 			log.Debugf("sending distance msg %s?", string(bytearray))

--- a/sense-go/modules/gpiorelay/dispenser_real.go
+++ b/sense-go/modules/gpiorelay/dispenser_real.go
@@ -107,7 +107,7 @@ func GetDispenserService() DispenserService {
 
 func (r *RealDispenser) SendDispenserStatusChangeEvent(dispenser_name string, on bool, sequence int32) {
 	log.Infof("Reporting switch %s status %#v", dispenser_name, on)
-	dm := messaging.NewDispenserStatusChangeMessage(dispenser_name, on)
+	dm := messaging.NewDispenserStatusChangeMessage(dispenser_name, on, messaging.GetNowMillis())
 	bytearray, err := json.Marshal(dm)
 	message := pb.SensorRequest{Sequence: sequence, TypeId: globals.Grpc_message_typeid_dispenser, Data: string(bytearray)}
 	if globals.Client == nil {

--- a/sense-go/modules/gpiorelay/powerstrip_real.go
+++ b/sense-go/modules/gpiorelay/powerstrip_real.go
@@ -71,7 +71,7 @@ func GetPowerstripService() PowerstripService {
 
 func (r *RealPowerStrip) SendSwitchStatusChangeEvent(switch_name string, on bool, sequence int32) {
 	log.Infof("Reporting switch %s status %#v", switch_name, on)
-	dm := messaging.NewSwitchStatusChangeMessage(switch_name, on)
+	dm := messaging.NewSwitchStatusChangeMessage(switch_name, on, messaging.GetNowMillis())
 	bytearray, err := json.Marshal(dm)
 	message := pb.SensorRequest{Sequence: sequence, TypeId: globals.Grpc_message_typeid_switch, Data: string(bytearray)}
 	if globals.Client == nil {

--- a/sense-go/modules/onewire/onewirereader.go
+++ b/sense-go/modules/onewire/onewirereader.go
@@ -79,7 +79,7 @@ func ReadOneWire() {
 				}
 				globals.LastWaterTemp = float32(fahrenheit)
 
-				phm := messaging.NewGenericSensorMessage(globals.Sensor_name_thermometer_water, globals.Measurement_name_temp_water, fahrenheit, globals.Temperature_units_fahrenheit, direction)
+				phm := messaging.NewGenericSensorMessage(globals.Sensor_name_thermometer_water, globals.Measurement_name_temp_water, fahrenheit, globals.Temperature_units_fahrenheit, direction, messaging.GetNowMillis())
 				bytearray, err := json.Marshal(phm)
 				message := pb.SensorRequest{Sequence: globals.GetSequence(), TypeId: globals.Grpc_message_typeid_sensor, Data: string(bytearray)}
 				if globals.Client != nil {

--- a/sense-go/modules/phsensor/ezo.go
+++ b/sense-go/modules/phsensor/ezo.go
@@ -92,7 +92,7 @@ func ReadPh(once_only bool) error {
 				direction = globals.Directions_down
 			}
 			lastPh = ph
-			phm := messaging.NewGenericSensorMessage(globals.Sensor_name_root_ph_sensor, globals.Measurement_name_root_ph, ph, globals.Ph_units_default, direction)
+			phm := messaging.NewGenericSensorMessage(globals.Sensor_name_root_ph_sensor, globals.Measurement_name_root_ph, ph, globals.Ph_units_default, direction, messaging.GetNowMillis())
 			bytearray, err := json.Marshal(phm)
 			message := pb.SensorRequest{Sequence: globals.GetSequence(), TypeId: globals.Grpc_message_typeid_sensor, Data: string(bytearray)}
 			if globals.Client != nil {


### PR DESCRIPTION
Pulled timestamp generation OUT of convenience functions and now pass it as parameter so that units will have same timestamp on newly generated message as the "desired outcome" message we have to compare it with.